### PR TITLE
Force nightly mode

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = firefox-wayland-hg
 	pkgdesc = Standalone web browser from mozilla.org - mozilla-unified hg, nightly branding, targeting wayland
-	pkgver = 123.0a1+20231228.1+ha0075cc44476
+	pkgver = 123.0a1+20231230.1+h9660032084db
 	pkgrel = 1
 	url = https://www.mozilla.org/firefox/channel/#nightly
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,7 +27,7 @@
 ## basic info
 pkgname="firefox${_pkgtype:-}"
 _pkgname=firefox-nightly
-pkgver=123.0a1+20231228.1+ha0075cc44476
+pkgver=123.0a1+20231230.1+h9660032084db
 pkgrel=1
 pkgdesc="Standalone web browser from mozilla.org"
 url="https://www.mozilla.org/firefox/channel/#nightly"
@@ -207,6 +207,7 @@ ac_add_options --with-distribution-id=org.archlinux
 ac_add_options --with-unsigned-addon-scopes=app,system
 ac_add_options --allow-addon-sideload
 export MOZILLA_OFFICIAL=1
+export NIGHTLY_BUILD=1
 export MOZ_APP_REMOTINGNAME=${_pkgname//-/}
 
 # Keys


### PR DESCRIPTION
Recent testing showed that setting the update channel alone is insufficient to enable all nightly features, like the ability to install unsigned extensions.  Setting `NIGHTLY_BUILD=1` resolves the problem. (Tested.)

Note: `aur/firefox-nightly` does not have this issue.  I am unable to figure out why.  Possibly some difference between `mozilla-central` and `mozilla-unified` repos.